### PR TITLE
fixed validator config and changed default email to jolocom.com

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
-import { BaseMetadata } from 'cred-types-jolocom-core'
-import { claimsMetadata as demoClaimsMetadata } from 'cred-types-jolocom-demo'
+import { BaseMetadata, claimsMetadata } from 'cred-types-jolocom-core'
 import { ICredentialReqSection } from './types'
+import { validateEmailCredential } from './helpers/validators';
 
 /**
  * The seed to instantiate a vaulted key provider and password for seed encryption / decryption
@@ -14,15 +14,16 @@ export const seed = Buffer.from(
 export const password = 'correct horse battery staple'
 
 /* Where is your service deployed. E.g. https://demo-sso.jolocom.com, used by the frontend */
-export const serviceUrl = 'http://192.168.2.109:9000'
+export const serviceUrl = 'https://60838dbf.ngrok.io'
 
 /* Credentials required during authentication */
-export const currentCredentialRequirements = ['a-kaart']
+export const currentCredentialRequirements = ['email']
 
 /* Credentials offered to users */
 export const credentialRequirements = {
-  'a-kaart': {
-    metadata: demoClaimsMetadata.akaart
+  'email': {
+    metadata: claimsMetadata.emailAddress,
+    credentialValidator: validateEmailCredential(['@jolocom.com'])
   }
 } as { [key: string]: ICredentialReqSection }
 

--- a/src/helpers/validators.ts
+++ b/src/helpers/validators.ts
@@ -22,7 +22,7 @@ export const validateEmailCredential = (whitelistedValues: string[]) => ({
 }) =>
   whitelistedValues.some(allowed =>
     allowed.startsWith('@')
-      ? validate(claim.email) && claim.email.endsWith(allowed)
+      ? validate.validate(claim.email) && claim.email.endsWith(allowed)
       : whitelistedValues.includes(claim.email)
   )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1501,6 +1501,7 @@ elliptic@^6.0.0, elliptic@^6.2.3, elliptic@^6.3.2, elliptic@^6.4.0, elliptic@^6.
 email-validator@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/email-validator/-/email-validator-2.0.4.tgz#b8dfaa5d0dae28f1b03c95881d904d4e40bfe7ed"
+  integrity sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==
 
 encodeurl@~1.0.2:
   version "1.0.2"


### PR DESCRIPTION
some fixes to enable the generic backend to run right after cloning, also removing reference to a-kaart