### PR TITLE
Jolocom lib v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "cred-types-jolocom-demo": "^0.2.1",
     "email-validator": "^2.0.4",
     "express": "^4.16.3",
-    "jolocom-lib": "^2.2.9",
+    "jolocom-lib": "^2.5.1",
     "redis": "^2.8.0",
     "socket.io": "^2.2.0",
     "tslib": "^1.9.3",

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,8 @@ import { BaseMetadata, claimsMetadata } from 'cred-types-jolocom-core'
 import { ICredentialReqSection } from './types'
 import {
   CredentialOfferMetadata,
-  CredentialOfferRenderInfo
+  CredentialOfferRenderInfo,
+  CredentialRenderTypes
 } from 'jolocom-lib/js/interactionTokens/interactionTokens.types'
 
 /**
@@ -17,7 +18,7 @@ export const seed = Buffer.from(
 export const password = 'correct horse battery staple'
 
 /* Where is your service deployed. E.g. https://demo-sso.jolocom.com, used by the frontend */
-export const serviceUrl = 'http://192.168.2.109:9000'
+export const serviceUrl = 'https://ecebe401.ngrok.io'
 
 /* Credentials required during authentication */
 export const currentCredentialRequirements = ['email']
@@ -30,7 +31,38 @@ export const credentialRequirements = {
 } as { [key: string]: ICredentialReqSection }
 
 /* Credentials offered by the service. Documentation on how to include custom credentials coming soon */
-export const credentialOffers = {} as {
+export const credentialOffers = {
+  testerBadge: {
+    schema: {
+      type: ['Credential', 'TesterCredential'],
+      context: [],
+      claimInterface: {
+        message: ''
+      },
+      name: 'Tester Badge'
+    },
+    requestedInput: {}, // currently not used
+    metadata: {
+      renderInfo: {
+        logo: {
+          url:
+            'https://miro.medium.com/fit/c/240/240/1*jbb5WdcAvaY1uVdCjX1XVg.png'
+        },
+        background: {
+          url:
+            'https://jolocom.io/wp-content/themes/jolocom/images/Solution-hero-mobile.jpg'
+        },
+        text: {
+          color: '#ffffff'
+        },
+        renderAs: CredentialRenderTypes.document
+      },
+      metadata: {
+        asynchronous: false // currently not used
+      },
+    }
+  }
+} as {
   [key: string]: {
     schema: BaseMetadata
     metadata: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,9 @@
-import { BaseMetadata } from 'cred-types-jolocom-core'
-import { claimsMetadata as demoClaimsMetadata } from 'cred-types-jolocom-demo'
+import { BaseMetadata, claimsMetadata } from 'cred-types-jolocom-core'
 import { ICredentialReqSection } from './types'
+import {
+  CredentialOfferMetadata,
+  CredentialOfferRenderInfo
+} from 'jolocom-lib/js/interactionTokens/interactionTokens.types'
 
 /**
  * The seed to instantiate a vaulted key provider and password for seed encryption / decryption
@@ -17,14 +20,22 @@ export const password = 'correct horse battery staple'
 export const serviceUrl = 'http://192.168.2.109:9000'
 
 /* Credentials required during authentication */
-export const currentCredentialRequirements = ['a-kaart']
+export const currentCredentialRequirements = ['email']
 
 /* Credentials offered to users */
 export const credentialRequirements = {
-  'a-kaart': {
-    metadata: demoClaimsMetadata.akaart
+  email: {
+    metadata: claimsMetadata.emailAddress
   }
 } as { [key: string]: ICredentialReqSection }
 
 /* Credentials offered by the service. Documentation on how to include custom credentials coming soon */
-export const credentialOffers = {} as { [key: string]: BaseMetadata }
+export const credentialOffers = {} as {
+  [key: string]: {
+    schema: BaseMetadata
+    metadata: {
+      renderInfo?: CredentialOfferRenderInfo
+      metadata?: CredentialOfferMetadata
+    }
+  }
+}

--- a/src/controllers/issuance.ts
+++ b/src/controllers/issuance.ts
@@ -12,14 +12,20 @@ const generateCredentialOffer = (
   const { credentialType } = req.params
 
   try {
-    const {type: offeredType} = credentialOffers[credentialType]
+    const {
+      schema: { type: offeredType },
+      metadata = {}
+    } = credentialOffers[credentialType]
 
     const credOffer = await identityWallet.create.interactionTokens.request.offer(
       {
         callbackURL: `${serviceUrl}/receive/${credentialType}`,
-        offeredCredentials: [{
-          type: offeredType[offeredType.length -1]
-        }]
+        offeredCredentials: [
+          {
+            type: offeredType[offeredType.length - 1],
+            ...metadata
+          }
+        ]
       },
       password
     )
@@ -47,7 +53,7 @@ const consumeCredentialOfferResponse = (
 
   const credential = await identityWallet.create.signedCredential(
     {
-      metadata: credentialOffers[credentialType],
+      metadata: credentialOffers[credentialType].schema,
       claim,
       subject: keyIdToDid(credentialOfferResponse.issuer)
     },

--- a/src/controllers/issuance.ts
+++ b/src/controllers/issuance.ts
@@ -54,7 +54,7 @@ const consumeCredentialOfferResponse = (
   const credential = await identityWallet.create.signedCredential(
     {
       metadata: credentialOffers[credentialType].schema,
-      claim,
+      claim: { ...claim, message: 'Thank you for testing the endpoint' },
       subject: keyIdToDid(credentialOfferResponse.issuer)
     },
     password

--- a/src/controllers/issuance.ts
+++ b/src/controllers/issuance.ts
@@ -12,11 +12,14 @@ const generateCredentialOffer = (
   const { credentialType } = req.params
 
   try {
+    const {type: offeredType} = credentialOffers[credentialType]
+
     const credOffer = await identityWallet.create.interactionTokens.request.offer(
       {
         callbackURL: `${serviceUrl}/receive/${credentialType}`,
-        requestedInput: {},
-        instant: true
+        offeredCredentials: [{
+          type: offeredType[offeredType.length -1]
+        }]
       },
       password
     )

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,7 +13,7 @@ const server = new http.Server(app)
 const redis = initializeRedisClient()
 
 const registry = JolocomLib.registries.jolocom.create()
-const vaultedKeyProvider = new JolocomLib.KeyProvider(seed, password)
+const vaultedKeyProvider = JolocomLib.KeyProvider.fromSeed(seed, password)
 const dbWatcher = new DbWatcher(redis.getAsync)
 
 registry

--- a/src/tester.ts
+++ b/src/tester.ts
@@ -1,7 +1,7 @@
 import { JolocomLib } from 'jolocom-lib'
 import { password, seed, serviceUrl } from './config'
 import axios, { AxiosResponse } from 'axios'
-import { claimsMetadata } from 'cred-types-jolocom-demo'
+import { claimsMetadata } from 'cred-types-jolocom-core'
 import { Endpoints } from './sockets'
 import { JSONWebToken } from 'jolocom-lib/js/interactionTokens/JSONWebToken'
 import { CredentialOfferRequest } from 'jolocom-lib/js/interactionTokens/credentialOfferRequest'
@@ -17,38 +17,39 @@ const getIdentityWallet = async () => {
   })
 }
 
-export const testCredentialReceive = async () => {
-  const identityWallet = await getIdentityWallet()
+// Currently not usable.
+// export const testCredentialReceive = async () => {
+//   const identityWallet = await getIdentityWallet()
+// 
+//   const { token } = (await axios.get(
+//     `${serviceUrl}${Endpoints.receive}id-card`
+//   )).data
+// 
+//   const credentialOffer: JSONWebToken<
+//     CredentialOfferRequest
+//   > = JolocomLib.parse.interactionToken.fromJWT(token)
+// 
+//   const offerResponse = await identityWallet.create.interactionTokens.response.offer(
+//     {
+//       callbackURL: credentialOffer.interactionToken.callbackURL,
+//       selectedCredentials: [
+//         {
+//           type: credentialOffer.interactionToken.offeredTypes[0]
+//         }
+//       ]
+//     },
+//     password,
+//     JolocomLib.parse.interactionToken.fromJWT(token)
+//   )
+// 
+//   return axios
+//     .post(`${serviceUrl}${Endpoints.receive}id-card`, {
+//       token: offerResponse.encode()
+//     })
+//     .catch(err => console.log(err))
+// }
 
-  const { token } = (await axios.get(
-    `${serviceUrl}${Endpoints.receive}id-card`
-  )).data
-
-  const credentialOffer: JSONWebToken<
-    CredentialOfferRequest
-  > = JolocomLib.parse.interactionToken.fromJWT(token)
-
-  const offerResponse = await identityWallet.create.interactionTokens.response.offer(
-    {
-      callbackURL: credentialOffer.interactionToken.callbackURL,
-      selectedCredentials: [
-        {
-          type: credentialOffer.interactionToken.offeredTypes[0]
-        }
-      ]
-    },
-    password,
-    JolocomLib.parse.interactionToken.fromJWT(token)
-  )
-
-  return axios
-    .post(`${serviceUrl}${Endpoints.receive}id-card`, {
-      token: offerResponse.encode()
-    })
-    .catch(err => console.log(err))
-}
-
-export const testCredentialOffer = async () => {
+export const testCredentialRequest = async () => {
   const identityWallet = await getIdentityWallet()
 
   const { token } = (await axios.get(`${serviceUrl}${Endpoints.authn}`)).data
@@ -60,9 +61,9 @@ export const testCredentialOffer = async () => {
     {
       subject: identityWallet.did,
       claim: {
-        identifier: '0123451612'
+        email: 'test@jolocom.com'
       },
-      metadata: claimsMetadata.akaart
+      metadata: claimsMetadata.emailAddress
     },
     password
   )
@@ -84,6 +85,7 @@ export const testCredentialOffer = async () => {
 }
 
 // testCredentialReceive().then((res: AxiosResponse) => console.log(res.status))
-testCredentialOffer()
+
+testCredentialRequest()
   .then((res: AxiosResponse) => console.log(res.status))
   .catch(err => console.log(err))

--- a/src/tester.ts
+++ b/src/tester.ts
@@ -6,6 +6,7 @@ import { Endpoints } from './sockets'
 import { JSONWebToken } from 'jolocom-lib/js/interactionTokens/JSONWebToken'
 import { CredentialOfferRequest } from 'jolocom-lib/js/interactionTokens/credentialOfferRequest'
 import { CredentialRequest } from 'jolocom-lib/js/interactionTokens/credentialRequest'
+import { CredentialsReceive } from 'jolocom-lib/js/interactionTokens/credentialsReceive'
 
 const getIdentityWallet = async () => {
   const registry = JolocomLib.registries.jolocom.create()
@@ -17,37 +18,36 @@ const getIdentityWallet = async () => {
   })
 }
 
-// Currently not usable.
-// export const testCredentialReceive = async () => {
-//   const identityWallet = await getIdentityWallet()
-// 
-//   const { token } = (await axios.get(
-//     `${serviceUrl}${Endpoints.receive}id-card`
-//   )).data
-// 
-//   const credentialOffer: JSONWebToken<
-//     CredentialOfferRequest
-//   > = JolocomLib.parse.interactionToken.fromJWT(token)
-// 
-//   const offerResponse = await identityWallet.create.interactionTokens.response.offer(
-//     {
-//       callbackURL: credentialOffer.interactionToken.callbackURL,
-//       selectedCredentials: [
-//         {
-//           type: credentialOffer.interactionToken.offeredTypes[0]
-//         }
-//       ]
-//     },
-//     password,
-//     JolocomLib.parse.interactionToken.fromJWT(token)
-//   )
-// 
-//   return axios
-//     .post(`${serviceUrl}${Endpoints.receive}id-card`, {
-//       token: offerResponse.encode()
-//     })
-//     .catch(err => console.log(err))
-// }
+export const testCredentialReceive = async () => {
+  const identityWallet = await getIdentityWallet()
+
+  const { token } = (await axios.get(
+    `${serviceUrl}${Endpoints.receive}testerBadge`
+  )).data
+
+  const credentialOffer: JSONWebToken<
+    CredentialOfferRequest
+  > = JolocomLib.parse.interactionToken.fromJWT(token)
+
+  const offerResponse = await identityWallet.create.interactionTokens.response.offer(
+    {
+      callbackURL: credentialOffer.interactionToken.callbackURL,
+      selectedCredentials: [
+        {
+          type: credentialOffer.interactionToken.offeredTypes[0]
+        }
+      ]
+    },
+    password,
+    JolocomLib.parse.interactionToken.fromJWT(token)
+  )
+
+  return axios
+    .post(credentialOffer.interactionToken.callbackURL, {
+      token: offerResponse.encode()
+    })
+    .catch(err => console.log(err))
+}
 
 export const testCredentialRequest = async () => {
   const identityWallet = await getIdentityWallet()
@@ -78,14 +78,21 @@ export const testCredentialRequest = async () => {
   )
 
   return axios
-    .post(`${serviceUrl}/authenticate`, {
+    .post(credentialRequest.interactionToken.callbackURL, {
       token: credentialResponse.encode()
     })
     .catch(err => console.log(err))
 }
 
-// testCredentialReceive().then((res: AxiosResponse) => console.log(res.status))
+testCredentialRequest().then((res: AxiosResponse) =>
+  console.log(`Sign in status code: ${res.status}`)
+)
 
-testCredentialRequest()
-  .then((res: AxiosResponse) => console.log(res.status))
+testCredentialReceive()
+  .then((res: AxiosResponse) => {
+    const credentials = JolocomLib.parse.interactionToken.fromJWT<
+      CredentialsReceive
+    >(res.data.token).interactionToken.signedCredentials
+    console.log('Received credentials: ', credentials)
+  })
   .catch(err => console.log(err))

--- a/yarn.lock
+++ b/yarn.lock
@@ -568,6 +568,16 @@
   version "11.9.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.9.5.tgz#011eece9d3f839a806b63973e228f85967b79ed3"
 
+"@types/node@11.11.6":
+  version "11.11.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
+  integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
+
+"@types/node@^10.3.2":
+  version "10.14.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.10.tgz#e491484c6060af8d461e12ec81c0da8a3282b8de"
+  integrity sha512-V8wj+w2YMNvGuhgl/MA5fmTxgjmVHVoasfIaxMMZJV6Y8Kk+Ydpi1z2whoShDCJ2BuNVoqH/h1hrygnBxkrw/Q==
+
 "@types/range-parser@*":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
@@ -617,6 +627,11 @@ accepts@~1.3.4, accepts@~1.3.5:
   dependencies:
     mime-types "~2.1.18"
     negotiator "0.6.1"
+
+aes-js@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
+  integrity sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=
 
 aes-js@^3.1.1:
   version "3.1.2"
@@ -675,7 +690,7 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-asn1.js@^4.0.0, asn1.js@^4.9.1:
+asn1.js@^4.0.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
   dependencies:
@@ -782,9 +797,10 @@ base64id@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/base64id/-/base64id-1.0.0.tgz#47688cb99bb6804f0e06d3e763b1c32e57d8e6b6"
 
-base64url@^3.0.0:
+base64url@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
+  integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
@@ -832,6 +848,16 @@ bip39@^2.2.0:
     randombytes "^2.0.1"
     safe-buffer "^5.0.1"
     unorm "^1.3.3"
+
+bip39@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.0.2.tgz#2baf42ff3071fc9ddd5103de92e8f80d9257ee32"
+  integrity sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==
+  dependencies:
+    "@types/node" "11.11.6"
+    create-hash "^1.1.0"
+    pbkdf2 "^3.0.9"
+    randombytes "^2.0.1"
 
 bip66@^1.1.3:
   version "1.1.5"
@@ -1256,10 +1282,6 @@ cred-types-jolocom-core@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/cred-types-jolocom-core/-/cred-types-jolocom-core-0.0.10.tgz#69dabc0fdb41a795fa6d63230d44a82d98e55dba"
 
-cred-types-jolocom-core@^0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/cred-types-jolocom-core/-/cred-types-jolocom-core-0.0.9.tgz#6d3a0a0b59838ec68f6e7fdf0ff234b349a1f42a"
-
 cred-types-jolocom-demo@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/cred-types-jolocom-demo/-/cred-types-jolocom-demo-0.2.1.tgz#bb89cfd4ec8c950c29bfe6886707dd0ce9396391"
@@ -1486,7 +1508,17 @@ electron-to-chromium@^1.3.113:
   version "1.3.113"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz#b1ccf619df7295aea17bc6951dc689632629e4a9"
 
-elliptic@^6.0.0, elliptic@^6.2.3, elliptic@^6.3.2, elliptic@^6.4.0, elliptic@^6.4.1:
+elliptic@6.3.3:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.3.3.tgz#5482d9646d54bcb89fd7d994fc9e2e9568876e3f"
+  integrity sha1-VILZZG1UvLif19mU/J4ulWiHbj8=
+  dependencies:
+    bn.js "^4.4.0"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    inherits "^2.0.1"
+
+elliptic@^6.0.0, elliptic@^6.2.3, elliptic@^6.4.0, elliptic@^6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
   dependencies:
@@ -1666,14 +1698,14 @@ ethereumjs-common@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/ethereumjs-common/-/ethereumjs-common-0.6.1.tgz#ec98edf315a7f107afb6acc48e937a8266979fae"
 
-ethereumjs-tx@^1.2.0, ethereumjs-tx@^1.2.2, ethereumjs-tx@^1.3.3:
+ethereumjs-tx@^1.2.0, ethereumjs-tx@^1.2.2, ethereumjs-tx@^1.3.3, ethereumjs-tx@^1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz#88323a2d875b10549b8347e09f4862b546f3d89a"
   dependencies:
     ethereum-common "^0.0.18"
     ethereumjs-util "^5.0.0"
 
-ethereumjs-util@^5.0.0, ethereumjs-util@^5.0.1, ethereumjs-util@^5.2.0:
+ethereumjs-util@^5.0.0, ethereumjs-util@^5.0.1:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz#3e0c0d1741471acf1036052d048623dee54ad642"
   dependencies:
@@ -1692,6 +1724,19 @@ ethereumjs-util@^6.0.0:
     bn.js "^4.11.0"
     create-hash "^1.1.2"
     ethjs-util "^0.1.6"
+    keccak "^1.0.2"
+    rlp "^2.0.0"
+    safe-buffer "^5.1.1"
+    secp256k1 "^3.0.1"
+
+ethereumjs-util@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz#e9c51e5549e8ebd757a339cc00f5380507e799c8"
+  integrity sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==
+  dependencies:
+    bn.js "^4.11.0"
+    create-hash "^1.1.2"
+    ethjs-util "0.1.6"
     keccak "^1.0.2"
     rlp "^2.0.0"
     safe-buffer "^5.1.1"
@@ -1727,6 +1772,22 @@ ethereumjs-wallet@^0.6.0:
     utf8 "^3.0.0"
     uuid "^3.3.2"
 
+ethers@^4.0.27:
+  version "4.0.31"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.31.tgz#50b066d8c74140944edfd2ad0a805162c30e3a20"
+  integrity sha512-S2zKBGvEBIng7hghAXZ9259xCkClyRr/bM0F297O3lAnC6sYjTHNIMtiqWmA89qieAIyzWUZn/aCLUslRlJFkw==
+  dependencies:
+    "@types/node" "^10.3.2"
+    aes-js "3.0.0"
+    bn.js "^4.4.0"
+    elliptic "6.3.3"
+    hash.js "1.1.3"
+    js-sha3 "0.5.7"
+    scrypt-js "2.0.4"
+    setimmediate "1.0.4"
+    uuid "2.0.1"
+    xmlhttprequest "1.8.0"
+
 ethjs-unit@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-unit/-/ethjs-unit-0.1.6.tgz#c665921e476e87bce2a9d588a6fe0405b2c41699"
@@ -1734,7 +1795,7 @@ ethjs-unit@0.1.6:
     bn.js "4.11.6"
     number-to-bn "1.7.0"
 
-ethjs-util@^0.1.3, ethjs-util@^0.1.6:
+ethjs-util@0.1.6, ethjs-util@^0.1.3, ethjs-util@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
   dependencies:
@@ -1888,7 +1949,16 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
-form-data@^2.3.2, form-data@~2.3.2:
+form-data@^2.3.3:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.4.0.tgz#4902b831b051e0db5612a35e1a098376f7b13ad8"
+  integrity sha512-4FinE8RfqYnNim20xDwZZE0V2kOs/AuElIjFUbPuegQSaoZM+vUT5FnwSl10KPugH4voTg1bEQlcbCG9ka75TA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
+form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
   dependencies:
@@ -2092,6 +2162,14 @@ hash-base@^3.0.0:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+hash.js@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.3.tgz#340dedbe6290187151c1ea1d777a3448935df846"
+  integrity sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.0"
 
 hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"
@@ -2318,26 +2396,30 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-jolocom-lib@^2.2.9:
-  version "2.2.9"
-  resolved "https://registry.yarnpkg.com/jolocom-lib/-/jolocom-lib-2.2.9.tgz#3529f8760c22ea33e4b3f48f0b1875ccbc57dbf0"
+jolocom-lib@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/jolocom-lib/-/jolocom-lib-2.5.1.tgz#aa455a2a96afc113f995d035006655ca15398fdb"
+  integrity sha512-rxyel9wD+2v0Xu1k2xqAzbvtv+TXTzi7UfJxbT5bW1odhvqeTvy6c/oiE9yVbUgsdIoxAyjjMhSjeZwDdzTP+g==
   dependencies:
-    base64url "^3.0.0"
+    base64url "^3.0.1"
     bip32 "^1.0.2"
+    bip39 "^3.0.1"
     class-transformer "^0.1.10"
     create-hash "^1.2.0"
-    cred-types-jolocom-core "^0.0.9"
+    cred-types-jolocom-core "^0.0.10"
     detect-node "^2.0.4"
-    ethereumjs-util "^5.2.0"
-    form-data "^2.3.2"
+    ethereumjs-tx "^1.3.7"
+    ethereumjs-util "^6.1.0"
+    ethers "^4.0.27"
+    form-data "^2.3.3"
     jolocom-registry-contract "^0.1.7"
     json-logic-js "^1.2.2"
-    jsonld "^1.0.1"
-    jsontokens "^0.7.8"
-    node-fetch "^2.1.2"
-    qrcode "^1.2.0"
-    reflect-metadata "^0.1.12"
-    sinon-chai "^3.2.0"
+    jsonld "^1.5.3"
+    jsontokens "^1.0.0"
+    node-fetch "^2.3.0"
+    qrcode "^1.3.3"
+    reflect-metadata "^0.1.13"
+    sinon-chai "^3.3.0"
     tiny-secp256k1 "^1.0.1"
 
 jolocom-registry-contract@^0.1.7:
@@ -2356,6 +2438,11 @@ jolocom-registry-contract@^0.1.7:
 js-levenshtein@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+
+js-sha3@0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
+  integrity sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=
 
 js-sha3@^0.6.1:
   version "0.6.1"
@@ -2416,24 +2503,26 @@ jsonfile@^2.1.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonld@^1.0.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/jsonld/-/jsonld-1.5.1.tgz#3b7a6060ba50157db92fdb550749bf600d504360"
+jsonld@^1.5.3:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/jsonld/-/jsonld-1.6.2.tgz#d81620dccf75fd7bc7501709eeec5da77ecc45e9"
+  integrity sha512-eMzFHqhF2kPMrMUjw8+Lz9IF1QkrxTOIfVndkP/OpuoZs31VdDtfDs8mLa5EOC/ROdemFTQGLdYPZbRtmMe2Yw==
   dependencies:
-    rdf-canonize "^1.0.1"
+    rdf-canonize "^1.0.2"
     request "^2.88.0"
     semver "^5.6.0"
     xmldom "0.1.19"
 
-jsontokens@^0.7.8:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/jsontokens/-/jsontokens-0.7.8.tgz#9210bb98944ee93a156c72754c1c281b2c52d419"
+jsontokens@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/jsontokens/-/jsontokens-1.0.0.tgz#f3dfa34bfd8a7e8dfdda0cfc197fc25e39a248e8"
+  integrity sha512-cC5q2qnJfwFQfN/P30Lo/m2v3x2D/JLUxli5tGP2367yRY5ZyEZSFpu+HQEBf2C8xlHL6DjQMYNFPdCFgQTmgA==
   dependencies:
-    asn1.js "^4.9.1"
-    base64url "^3.0.0"
-    elliptic "^6.3.2"
-    key-encoder "^1.1.6"
-    validator "^7.0.0"
+    asn1.js "^5.0.1"
+    base64url "^3.0.1"
+    elliptic "^6.4.1"
+    key-encoder "^1.1.7"
+    validator "^10.9.0"
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -2460,9 +2549,10 @@ keccakjs@^0.2.1:
     browserify-sha3 "^0.0.4"
     sha3 "^1.2.2"
 
-key-encoder@^1.1.6:
+key-encoder@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/key-encoder/-/key-encoder-1.1.7.tgz#af139f34910fc7c6f828a02ccf71d8d662d8e495"
+  integrity sha512-7qjnX+t+l1kPeozKAm3/UO216/HseXw7xxXd8WkT2i/moFIZIN46RzoaCeScBoEwGF2mUUuPRu4j8EHP0BGfpg==
   dependencies:
     asn1.js "^5.0.1"
     bn.js "^4.11.8"
@@ -2771,13 +2861,15 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-fetch@^2.1.2:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
+node-fetch@^2.3.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
-node-forge@^0.7.6:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.6.tgz#fdf3b418aee1f94f0ef642cd63486c77ca9724ac"
+node-forge@^0.8.1:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.8.5.tgz#57906f07614dc72762c84cef442f427c0e1b86ee"
+  integrity sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==
 
 node-releases@^1.1.8:
   version "1.1.8"
@@ -3088,9 +3180,10 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
-qrcode@^1.2.0:
+qrcode@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/qrcode/-/qrcode-1.3.3.tgz#5ef50c0c890cffa1897f452070f0f094936993de"
+  integrity sha512-SH7V13AcJusH3GT8bMNOGz4w0L+LjcpNOU/NiOgtBhT/5DoWeZE6D5ntMJnJ84AMkoaM4kjJJoHoh9g++8lWFg==
   dependencies:
     can-promise "0.0.1"
     dijkstrajs "^1.0.1"
@@ -3140,11 +3233,12 @@ raw-body@2.3.3:
     iconv-lite "0.4.23"
     unpipe "1.0.0"
 
-rdf-canonize@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/rdf-canonize/-/rdf-canonize-1.0.1.tgz#0a200a12c169e0008dd10e5b2b3855a55db0626c"
+rdf-canonize@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/rdf-canonize/-/rdf-canonize-1.0.3.tgz#71dc56bb808a39d12e3ca17674c15f881cad648a"
+  integrity sha512-piLMOB5Q6LJSVx2XzmdpHktYVb8TmVTy8coXJBFtdkcMC96DknZOuzpAYqCWx2ERZX7xEW+mMi8/wDuMJS/95w==
   dependencies:
-    node-forge "^0.7.6"
+    node-forge "^0.8.1"
     semver "^5.6.0"
 
 read-pkg-up@^1.0.1:
@@ -3208,9 +3302,10 @@ redis@^2.8.0:
     redis-commands "^1.2.0"
     redis-parser "^2.6.0"
 
-reflect-metadata@^0.1.12:
+reflect-metadata@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
+  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
 
 regenerate-unicode-properties@^7.0.0:
   version "7.0.0"
@@ -3340,6 +3435,11 @@ safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, s
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
+scrypt-js@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.4.tgz#32f8c5149f0797672e551c07e230f834b6af5f16"
+  integrity sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==
+
 scrypt.js@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/scrypt.js/-/scrypt.js-0.2.0.tgz#af8d1465b71e9990110bedfc593b9479e03a8ada"
@@ -3439,6 +3539,11 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
+setimmediate@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.4.tgz#20e81de622d4a02588ce0c8da8973cbcf1d3138f"
+  integrity sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=
+
 setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
@@ -3486,9 +3591,10 @@ simple-get@^2.7.0:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
-sinon-chai@^3.2.0:
+sinon-chai@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.3.0.tgz#8084ff99451064910fbe2c2cb8ab540c00b740ea"
+  integrity sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==
 
 socket.io-adapter@~1.1.0:
   version "1.1.1"
@@ -4024,9 +4130,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-validator@^7.0.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-7.2.0.tgz#a63dcbaba51d4350bf8df20988e0d5a54d711791"
+validator@^10.9.0:
+  version "10.11.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-10.11.0.tgz#003108ea6e9a9874d31ccc9e5006856ccd76b228"
+  integrity sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"
@@ -4378,7 +4485,7 @@ xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
 
-xmlhttprequest@*:
+xmlhttprequest@*, xmlhttprequest@1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
 


### PR DESCRIPTION
Updates to the generic backend to use the upcoming version of the Jolocom-Lib (v3.0).

Can be merged once [this](https://github.com/jolocom/jolocom-lib/pull/311) is merged, and a new version of the Jolocom Library is released.

#### TODO
- [x] Ensure Slite documentation is up to date and contains no dead links.
- [x] Add basic test script for the credential offer flow.
- [x] Update the `README` to include / reference documentation.